### PR TITLE
Added utility functions for Csr and Csc Matrices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "single_algebra"
-version = "0.1.0-alpha.3"
+version = "0.1.1-alpha.0"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "single_algebra"
-version = "0.1.0-alpha.3"
+version = "0.1.1-alpha.0"
 edition = "2021"
 license-file = "LICENSE.md"
 description = "A linear algebra convenience library for the single-rust library. Can be used externally as well."

--- a/src/sparse/csc.rs
+++ b/src/sparse/csc.rs
@@ -5,9 +5,9 @@ use num_traits::{PrimInt, Unsigned, Zero};
 
 use crate::NumericOps;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Result};
 
-use super::MatrixNonZero;
+use super::{MatrixNonZero, MatrixSum, MatrixVariance};
 
 impl<M: NumericOps> MatrixNonZero for CscMatrix<M> {
     fn nonzero_col<T>(&self) -> anyhow::Result<Vec<T>>
@@ -20,8 +20,11 @@ impl<M: NumericOps> MatrixNonZero for CscMatrix<M> {
             .map(|window| {
                 let diff = window[1]
                     .checked_sub(window[0])
-                    .ok_or_else(|| anyhow!("Subtraction overflow")).expect("Subtraction overflow");
-                T::from(diff).ok_or_else(|| anyhow!("Failed to convert to target type")).expect("Failed to convert to a target type")
+                    .ok_or_else(|| anyhow!("Subtraction overflow"))
+                    .expect("Subtraction overflow");
+                T::from(diff)
+                    .ok_or_else(|| anyhow!("Failed to convert to target type"))
+                    .expect("Failed to convert to a target type")
             })
             .collect();
         Ok(data)
@@ -50,7 +53,7 @@ impl<M: NumericOps> MatrixNonZero for CscMatrix<M> {
                 T::from(count).ok_or_else(|| anyhow!("Failed to convert to target type"))?;
             if i < reference.len() {
                 reference[i] += count_transformed;
-            } 
+            }
         }
         Ok(())
     }
@@ -68,6 +71,192 @@ impl<M: NumericOps> MatrixNonZero for CscMatrix<M> {
     }
 }
 
+impl<M: NumericOps> MatrixSum for CscMatrix<M> {
+    type Item = M;
+
+    fn sum_col<T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        let mut result = vec![T::zero(); self.ncols()];
+        for (col, col_vec) in self.col_iter().enumerate() {
+            result[col] = col_vec.values().iter().map(|&v| T::from(v).unwrap()).sum();
+        }
+        Ok(result)
+    }
+
+    fn sum_row<T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        let mut result = vec![T::zero(); self.nrows()];
+        for (&row_index, &value) in self.row_indices().iter().zip(self.values().iter()) {
+            result[row_index] += T::from(value).unwrap();
+        }
+        Ok(result)
+    }
+
+    fn sum_col_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        for (col, col_vec) in self.col_iter().enumerate() {
+            if col < reference.len() {
+                reference[col] += col_vec.values().iter().map(|&v| T::from(v).unwrap()).sum();
+            }
+        }
+        Ok(())
+    }
+
+    fn sum_row_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        for (&row_index, &value) in self.row_indices().iter().zip(self.values().iter()) {
+            if row_index < reference.len() {
+                reference[row_index] += T::from(value).unwrap();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<M: NumericOps> MatrixVariance for CscMatrix<M> {
+    type Item = M;
+
+    fn var_col<I, T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast + MatrixSum + MatrixNonZero,
+    {
+        let sum: Vec<T> = self.sum_row()?;
+        let count: Vec<I> = self.nonzero_row()?;
+
+        let mut result = vec![T::zero(); self.ncols()];
+        for (col, col_vec) in self.col_iter().enumerate() {
+            let mean = sum[col] / count[col].into();
+            let variance = col_vec
+                .values()
+                .iter()
+                .map(|&v| {
+                    let diff = T::from(v).unwrap() - mean;
+                    diff * diff
+                })
+                .sum::<T>()
+                / count[col].into();
+            result[col] = variance;
+        }
+        Ok(result)
+    }
+
+    fn var_row<I, T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast + MatrixSum + MatrixNonZero,
+    {
+        let sum: Vec<T> = self.sum_row()?;
+        let count: Vec<I> = self.nonzero_row()?;
+
+        let mut result = vec![T::zero(); self.nrows()];
+        let mut squared_sum = vec![T::zero(); self.nrows()];
+        for (&row_index, &value) in self.row_indices().iter().zip(self.values().iter()) {
+            let val = T::from(value).unwrap();
+            squared_sum[row_index] += val * val;
+        }
+        for row in 0..self.nrows() {
+            if count[row] > I::zero() {
+                let mean = sum[row] / count[row].into();
+                result[row] = squared_sum[row] / count[row].into() - mean * mean;
+            }
+        }
+        Ok(result)
+    }
+
+    fn var_col_chunk<I, T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        // Validate input slice length matches number of columns
+        if reference.len() != self.ncols() {
+            return Err(anyhow::anyhow!(
+                "Reference slice length {} does not match number of columns {}",
+                reference.len(),
+                self.ncols()
+            ));
+        }
+
+        let sum: Vec<T> = self.sum_row()?;
+        let count: Vec<I> = self.nonzero_row()?;
+
+        // Calculate variance for each column in-place
+        for (col, col_vec) in self.col_iter().enumerate() {
+            if count[col] > I::zero() {
+                let mean = sum[col] / count[col].into();
+                let variance = col_vec
+                    .values()
+                    .iter()
+                    .map(|&v| {
+                        let diff = T::from(v).unwrap() - mean;
+                        diff * diff
+                    })
+                    .sum::<T>()
+                    / count[col].into();
+                reference[col] = variance;
+            } else {
+                reference[col] = T::zero();
+            }
+        }
+        Ok(())
+    }
+
+    fn var_row_chunk<I, T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: num_traits::Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        // Validate input slice length matches number of rows
+        if reference.len() != self.nrows() {
+            return Err(anyhow::anyhow!(
+                "Reference slice length {} does not match number of rows {}",
+                reference.len(),
+                self.nrows()
+            ));
+        }
+
+        let sum: Vec<T> = self.sum_row()?;
+        let count: Vec<I> = self.nonzero_row()?;
+
+        // Initialize squared sum vector
+        let mut squared_sum = vec![T::zero(); self.nrows()];
+
+        // Calculate squared sums
+        for (&row_index, &value) in self.row_indices().iter().zip(self.values().iter()) {
+            let val = T::from(value).unwrap();
+            squared_sum[row_index] += val * val;
+        }
+
+        // Calculate variance for each row in-place
+        for row in 0..self.nrows() {
+            if count[row] > I::zero() {
+                let mean = sum[row] / count[row].into();
+                reference[row] = squared_sum[row] / count[row].into() - mean * mean;
+            } else {
+                reference[row] = T::zero();
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,28 +268,27 @@ mod tests {
         // [0 0 0]
         // [3 4 0]
         // [0 5 6]
-        
+
         // For CSC format we need:
         // 1. Values in column-major order
         // 2. Row indices for each value
         // 3. Column pointers indicating where each column starts
-        
+
         let values = vec![1.0, 3.0, 4.0, 5.0, 2.0, 6.0];
         let row_indices = vec![0, 2, 2, 3, 0, 3];
         let col_ptrs = vec![0, 2, 4, 6];
-        
+
         CscMatrix::try_from_csc_data(4, 3, col_ptrs, row_indices, values).unwrap()
     }
-
 
     #[test]
     fn test_nonzero_row() {
         let matrix = create_test_matrix();
         let result: Vec<u32> = matrix.nonzero_row().unwrap();
-        
+
         // Row-wise nonzero counts
         assert_eq!(result, vec![2, 0, 2, 2]);
-        
+
         // Verify through column iteration
         let mut row_counts = vec![0u32; matrix.nrows()];
         for col_idx in 0..matrix.ncols() {
@@ -117,7 +305,7 @@ mod tests {
         let empty: CscMatrix<f64> = CscMatrix::zeros(0, 0);
         assert!(empty.nonzero_col::<u32>().unwrap().is_empty());
         assert!(empty.nonzero_row::<u32>().unwrap().is_empty());
-        
+
         // Zero matrix
         let zero: CscMatrix<f64> = CscMatrix::zeros(4, 3);
         assert_eq!(zero.nonzero_col::<u32>().unwrap(), vec![0, 0, 0]);
@@ -131,7 +319,7 @@ mod tests {
         let mut row_indices = Vec::new();
         let mut col_ptrs = vec![0];
         let mut current_nnz = 0;
-        
+
         // Create a tridiagonal matrix in CSC format
         for col in 0..n {
             if col > 0 {
@@ -149,31 +337,29 @@ mod tests {
             }
             col_ptrs.push(current_nnz);
         }
-        
-        let matrix = CscMatrix::try_from_csc_data(
-            n, n, col_ptrs, row_indices, values
-        ).unwrap();
-        
+
+        let matrix = CscMatrix::try_from_csc_data(n, n, col_ptrs, row_indices, values).unwrap();
+
         // Verify structure
         assert_eq!(matrix.nrows(), n);
         assert_eq!(matrix.ncols(), n);
-        
+
         // Test column nonzeros
         let col_nnz: Vec<u32> = matrix.nonzero_col().unwrap();
         assert_eq!(col_nnz[0], 2); // First column: 2 nonzeros
-        assert_eq!(col_nnz[n/2], 3); // Middle columns: 3 nonzeros
-        assert_eq!(col_nnz[n-1], 2); // Last column: 2 nonzeros
+        assert_eq!(col_nnz[n / 2], 3); // Middle columns: 3 nonzeros
+        assert_eq!(col_nnz[n - 1], 2); // Last column: 2 nonzeros
     }
 
     #[test]
     fn test_chunk_operations() {
         let matrix = create_test_matrix();
-        
+
         // Test column chunks
         let mut col_chunk = vec![0u32; 2];
         matrix.nonzero_col_chunk(&mut col_chunk).unwrap();
         assert_eq!(col_chunk, vec![2, 2]);
-        
+
         // Test row chunks
         let mut row_chunk = vec![0u32; 3];
         matrix.nonzero_row_chunk(&mut row_chunk).unwrap();

--- a/src/sparse/csc.rs
+++ b/src/sparse/csc.rs
@@ -67,3 +67,116 @@ impl<M: NumericOps> MatrixNonZero for CscMatrix<M> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra_sparse::CscMatrix;
+
+    fn create_test_matrix() -> CscMatrix<f64> {
+        // Create a 4x3 CSC matrix directly with the following structure:
+        // [1 0 2]
+        // [0 0 0]
+        // [3 4 0]
+        // [0 5 6]
+        
+        // For CSC format we need:
+        // 1. Values in column-major order
+        // 2. Row indices for each value
+        // 3. Column pointers indicating where each column starts
+        
+        let values = vec![1.0, 3.0, 4.0, 5.0, 2.0, 6.0];
+        let row_indices = vec![0, 2, 2, 3, 0, 3];
+        let col_ptrs = vec![0, 2, 4, 6];
+        
+        CscMatrix::try_from_csc_data(4, 3, col_ptrs, row_indices, values).unwrap()
+    }
+
+
+    #[test]
+    fn test_nonzero_row() {
+        let matrix = create_test_matrix();
+        let result: Vec<u32> = matrix.nonzero_row().unwrap();
+        
+        // Row-wise nonzero counts
+        assert_eq!(result, vec![2, 0, 2, 2]);
+        
+        // Verify through column iteration
+        let mut row_counts = vec![0u32; matrix.nrows()];
+        for col_idx in 0..matrix.ncols() {
+            for &row_idx in matrix.col(col_idx).row_indices() {
+                row_counts[row_idx] += 1;
+            }
+        }
+        assert_eq!(result, row_counts);
+    }
+
+    #[test]
+    fn test_empty_and_zero_matrices() {
+        // Empty matrix
+        let empty: CscMatrix<f64> = CscMatrix::zeros(0, 0);
+        assert!(empty.nonzero_col::<u32>().unwrap().is_empty());
+        assert!(empty.nonzero_row::<u32>().unwrap().is_empty());
+        
+        // Zero matrix
+        let zero: CscMatrix<f64> = CscMatrix::zeros(4, 3);
+        assert_eq!(zero.nonzero_col::<u32>().unwrap(), vec![0, 0, 0]);
+        assert_eq!(zero.nonzero_row::<u32>().unwrap(), vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_large_sparse_matrix() {
+        let n = 1000;
+        let mut values = Vec::new();
+        let mut row_indices = Vec::new();
+        let mut col_ptrs = vec![0];
+        let mut current_nnz = 0;
+        
+        // Create a tridiagonal matrix in CSC format
+        for col in 0..n {
+            if col > 0 {
+                values.push(1.0);
+                row_indices.push(col - 1);
+                current_nnz += 1;
+            }
+            values.push(2.0);
+            row_indices.push(col);
+            current_nnz += 1;
+            if col < n - 1 {
+                values.push(1.0);
+                row_indices.push(col + 1);
+                current_nnz += 1;
+            }
+            col_ptrs.push(current_nnz);
+        }
+        
+        let matrix = CscMatrix::try_from_csc_data(
+            n, n, col_ptrs, row_indices, values
+        ).unwrap();
+        
+        // Verify structure
+        assert_eq!(matrix.nrows(), n);
+        assert_eq!(matrix.ncols(), n);
+        
+        // Test column nonzeros
+        let col_nnz: Vec<u32> = matrix.nonzero_col().unwrap();
+        assert_eq!(col_nnz[0], 2); // First column: 2 nonzeros
+        assert_eq!(col_nnz[n/2], 3); // Middle columns: 3 nonzeros
+        assert_eq!(col_nnz[n-1], 2); // Last column: 2 nonzeros
+    }
+
+    #[test]
+    fn test_chunk_operations() {
+        let matrix = create_test_matrix();
+        
+        // Test column chunks
+        let mut col_chunk = vec![0u32; 2];
+        matrix.nonzero_col_chunk(&mut col_chunk).unwrap();
+        assert_eq!(col_chunk, vec![2, 2]);
+        
+        // Test row chunks
+        let mut row_chunk = vec![0u32; 3];
+        matrix.nonzero_row_chunk(&mut row_chunk).unwrap();
+        assert_eq!(row_chunk, vec![2, 0, 2]);
+    }
+}

--- a/src/sparse/csr.rs
+++ b/src/sparse/csr.rs
@@ -2,11 +2,11 @@ use std::ops::AddAssign;
 
 use anyhow::{anyhow, Ok};
 use nalgebra_sparse::CsrMatrix;
-use num_traits::{PrimInt, Unsigned, Zero};
+use num_traits::{Float, PrimInt, Unsigned, Zero};
 
 use crate::NumericOps;
 
-use super::MatrixNonZero;
+use super::{MatrixNonZero, MatrixSum};
 
 impl<M: NumericOps> MatrixNonZero for CsrMatrix<M> {
     fn nonzero_col<T>(&self) -> anyhow::Result<Vec<T>>
@@ -30,8 +30,11 @@ impl<M: NumericOps> MatrixNonZero for CsrMatrix<M> {
             .map(|window| {
                 let diff = window[1]
                     .checked_sub(window[0])
-                    .ok_or_else(|| anyhow!("Subtraction overflow")).expect("Subtraction overflow");
-                T::from(diff).ok_or_else(|| anyhow!("Failed to convert to target type")).expect("Failed to convert to targat type")
+                    .ok_or_else(|| anyhow!("Subtraction overflow"))
+                    .expect("Subtraction overflow");
+                T::from(diff)
+                    .ok_or_else(|| anyhow!("Failed to convert to target type"))
+                    .expect("Failed to convert to targat type")
             })
             .collect();
         Ok(data)
@@ -67,10 +70,63 @@ impl<M: NumericOps> MatrixNonZero for CsrMatrix<M> {
     }
 }
 
+impl<M: NumericOps> MatrixSum for CsrMatrix<M> {
+    type Item = M;
+
+    fn sum_col<T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        let mut result = vec![T::zero(); self.ncols()];
+        for (&col_indices, &value) in self.col_indices().iter().zip(self.values().iter()) {
+            result[col_indices] += T::from(value).unwrap();
+        }
+
+        Ok(result)
+    }
+
+    fn sum_row<T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        let mut result = vec![T::zero(); self.nrows()];
+        for (row, row_vec) in self.row_iter().enumerate() {
+            result[row] = row_vec.values().iter().map(|&v| T::from(v).unwrap()).sum();
+        }
+        Ok(result)
+    }
+
+    fn sum_col_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        for (&col_index, &value) in self.col_indices().iter().zip(self.values().iter()) {
+            if col_index < reference.len() {
+                reference[col_index] += T::from(value).unwrap();
+            }
+        }
+        Ok(())
+    }
+
+    fn sum_row_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        T: Float + num_traits::NumCast+ AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast,
+    {
+        for (row, row_vec) in self.row_iter().enumerate() {
+            reference[row] = row_vec.values().iter().map(|&v| T::from(v).unwrap()).sum();
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nalgebra_sparse::{CscMatrix, CooMatrix};
+    use nalgebra_sparse::{CooMatrix, CscMatrix};
 
     fn create_test_matrix() -> CscMatrix<f64> {
         // Create a 4x3 sparse matrix with the following structure:
@@ -78,18 +134,18 @@ mod tests {
         // [0 0 0]
         // [3 4 0]
         // [0 5 6]
-        
+
         // First create a COO matrix and then convert to CSC
         let mut coo = CooMatrix::new(4, 3);
         coo.push(0, 0, 1.0); // First column
         coo.push(2, 0, 3.0);
-        
+
         coo.push(2, 1, 4.0); // Second column
         coo.push(3, 1, 5.0);
-        
+
         coo.push(0, 2, 2.0); // Third column
         coo.push(3, 2, 6.0);
-        
+
         CscMatrix::from(&coo)
     }
 
@@ -97,7 +153,7 @@ mod tests {
     fn test_nonzero_col() {
         let matrix = create_test_matrix();
         let result: Vec<u32> = matrix.nonzero_col().unwrap();
-        
+
         // Expected number of nonzero elements in each column
         assert_eq!(result, vec![2, 2, 2]);
     }
@@ -106,7 +162,7 @@ mod tests {
     fn test_nonzero_row() {
         let matrix = create_test_matrix();
         let result: Vec<u32> = matrix.nonzero_row().unwrap();
-        
+
         // Expected number of nonzero elements in each row
         assert_eq!(result, vec![2, 0, 2, 2]);
     }
@@ -116,7 +172,7 @@ mod tests {
         let matrix = create_test_matrix();
         let mut reference = vec![0u32; 4];
         matrix.nonzero_col_chunk(&mut reference).unwrap();
-        
+
         // Only first 3 elements should be modified (matrix has 3 columns)
         assert_eq!(reference, vec![2, 2, 2, 0]);
     }
@@ -126,7 +182,7 @@ mod tests {
         let matrix = create_test_matrix();
         let mut reference = vec![0u32; 3];
         matrix.nonzero_row_chunk(&mut reference).unwrap();
-        
+
         // Should only count nonzeros for rows within reference length
         assert_eq!(reference, vec![2, 0, 2]);
     }
@@ -134,11 +190,11 @@ mod tests {
     #[test]
     fn test_empty_matrix() {
         let matrix: CscMatrix<f64> = CscMatrix::zeros(0, 0);
-        
+
         // Test empty matrix handling
         assert!(matrix.nonzero_col::<u32>().unwrap().is_empty());
         assert!(matrix.nonzero_row::<u32>().unwrap().is_empty());
-        
+
         let mut empty_ref: Vec<u32> = Vec::new();
         assert!(matrix.nonzero_col_chunk(&mut empty_ref).is_ok());
         assert!(matrix.nonzero_row_chunk(&mut empty_ref).is_ok());
@@ -147,11 +203,11 @@ mod tests {
     #[test]
     fn test_different_integer_types() {
         let matrix = create_test_matrix();
-        
+
         // Test with u8
         let result_u8: Vec<u8> = matrix.nonzero_col().unwrap();
         assert_eq!(result_u8, vec![2, 2, 2]);
-        
+
         // Test with u64
         let result_u64: Vec<u64> = matrix.nonzero_col().unwrap();
         assert_eq!(result_u64, vec![2, 2, 2]);
@@ -161,17 +217,17 @@ mod tests {
     fn test_large_sparse_matrix() {
         // Create a larger sparse matrix to test potential overflow conditions
         let mut coo = CooMatrix::new(1000, 1000);
-        
+
         // Add some sparse data
         for i in 0..999 {
             coo.push(i, i, 1.0);
             coo.push(i + 1, i, 1.0);
         }
-        
+
         let matrix = CscMatrix::from(&coo);
         let result: Vec<u32> = matrix.nonzero_col().unwrap();
         assert_eq!(result.len(), 1000);
-        
+
         // Most columns should have 2 nonzero elements
         assert_eq!(result[500], 2);
     }
@@ -179,12 +235,12 @@ mod tests {
     #[test]
     fn test_chunk_smaller_than_matrix() {
         let matrix = create_test_matrix();
-        
+
         // Test with smaller reference slices
         let mut col_ref = vec![0u32; 2];
         matrix.nonzero_col_chunk(&mut col_ref).unwrap();
         assert_eq!(col_ref, vec![2, 2]);
-        
+
         let mut row_ref = vec![0u32; 2];
         matrix.nonzero_row_chunk(&mut row_ref).unwrap();
         assert_eq!(row_ref, vec![2, 0]);
@@ -194,10 +250,10 @@ mod tests {
     fn test_zero_matrix() {
         // Test a non-empty matrix with all zero elements
         let matrix: CscMatrix<f64> = CscMatrix::zeros(5, 4);
-        
+
         let col_result: Vec<u32> = matrix.nonzero_col().unwrap();
         assert_eq!(col_result, vec![0, 0, 0, 0]);
-        
+
         let row_result: Vec<u32> = matrix.nonzero_row().unwrap();
         assert_eq!(row_result, vec![0, 0, 0, 0, 0]);
     }

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -1,4 +1,4 @@
-use std::ops::{AddAssign};
+use std::ops::AddAssign;
 
 use num_traits::{Float, NumCast, PrimInt, Unsigned, Zero};
 
@@ -24,39 +24,55 @@ pub trait MatrixNonZero {
 }
 
 pub trait MatrixSum {
-    fn sum_col<T>(&self) -> anyhow::Result<T>
-    where
-        T: Float;
+    type Item;
 
-    fn sum_row<T>(&self) -> anyhow::Result<T>
+    fn sum_col<T>(&self) -> anyhow::Result<Vec<T>>
     where
-        T: Float;
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
+
+    fn sum_row<T>(&self) -> anyhow::Result<Vec<T>>
+    where
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
 
     fn sum_col_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
     where
-        T: Float;
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
 
     fn sum_row_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
     where
-        T: Float;
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
 }
 
 pub trait MatrixVariance {
-    fn var_col<T>(&self) -> anyhow::Result<Vec<T>>
-    where
-        T: Float;
+    type Item;
 
-    fn var_row<T>(&self) -> anyhow::Result<Vec<T>>
+    fn var_col<I, T>(&self) -> anyhow::Result<Vec<T>>
     where
-        T: Float;
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast + MatrixSum + MatrixNonZero;
 
-    fn var_col_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    fn var_row<I, T>(&self) -> anyhow::Result<Vec<T>>
     where
-        T: Float;
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast + MatrixSum + MatrixNonZero;
 
-    fn var_row_chunk<T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    fn var_col_chunk<I, T>(&self, reference: &mut [T]) -> anyhow::Result<()>
     where
-        T: Float;
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
+
+    fn var_row_chunk<I, T>(&self, reference: &mut [T]) -> anyhow::Result<()>
+    where
+        I: PrimInt + Unsigned + Zero + AddAssign + Into<T>,
+        T: Float + num_traits::NumCast + AddAssign + std::iter::Sum,
+        Self::Item: num_traits::NumCast;
 }
 
 pub trait MatrixMinMax {

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -2,6 +2,8 @@ use std::ops::AddAssign;
 
 use num_traits::{Float, NumCast, PrimInt, Unsigned, Zero};
 
+use crate::NumericOps;
+
 pub mod csc;
 pub mod csr;
 
@@ -76,19 +78,21 @@ pub trait MatrixVariance {
 }
 
 pub trait MatrixMinMax {
-    fn min_max_col<T>(&self) -> anyhow::Result<(Vec<T>, Vec<T>)>
-    where
-        T: NumCast + Copy + PartialOrd;
+    type Item;
 
-    fn min_max_row<T>(&self) -> anyhow::Result<(Vec<T>, Vec<T>)>
+    fn min_max_col<Item>(&self) -> anyhow::Result<(Vec<Item>, Vec<Item>)>
     where
-        T: NumCast + Copy + PartialOrd;
+        Item: NumCast + Copy + PartialOrd + NumericOps;
 
-    fn min_max_col_chunk<T>(&self, reference: &mut (Vec<T>, Vec<T>)) -> anyhow::Result<()>
+    fn min_max_row<Item>(&self) -> anyhow::Result<(Vec<Item>, Vec<Item>)>
     where
-        T: NumCast + Copy + PartialOrd;
+        Item: NumCast + Copy + PartialOrd + NumericOps;
 
-    fn min_max_row_chunk<T>(&self, reference: &mut (Vec<T>, Vec<T>)) -> anyhow::Result<()>
+    fn min_max_col_chunk<Item>(&self, reference: (&mut Vec<Item>, &mut Vec<Item>)) -> anyhow::Result<()>
     where
-        T: NumCast + Copy + PartialOrd;
+        Item: NumCast + Copy + PartialOrd + NumericOps;
+
+    fn min_max_row_chunk<Item>(&self, reference: (&mut Vec<Item>, &mut Vec<Item>)) -> anyhow::Result<()>
+    where
+        Item: NumCast + Copy + PartialOrd + NumericOps;
 }

--- a/src/sparse/mod.rs
+++ b/src/sparse/mod.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign};
+use std::ops::{AddAssign};
 
 use num_traits::{Float, NumCast, PrimInt, Unsigned, Zero};
 


### PR DESCRIPTION
This enables us to move that functionality from the SingleRust crate into the single-algebra crate, this should allow us to implement optimizations like parallel processing or the utilization of SIMD in the future.